### PR TITLE
Improve Error Messaging for Missing Bash Profile in Setup

### DIFF
--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use anyhow::{bail, Result};
 use dialoguer::{theme::ColorfulTheme, Select};
 use tracing::{error, info};
@@ -54,7 +56,17 @@ eval "$(cocmd profile-loader)"
         }
         _ => unreachable!(),
     };
-    let mut profile = std::fs::read_to_string(&profile_path).unwrap();
+    let mut profile = match std::fs::read_to_string(&profile_path) {
+        Ok(content) => content,
+        Err(e) => {
+            eprintln!(
+                "Failed to read the file at {}: {}",
+                Path::new(&profile_path).display(),
+                e
+            );
+            return Err(anyhow::Error::new(e));
+        }
+    };
 
     // check if profile_loader is already in profile
     if profile.contains("cocmd profile-loader") {


### PR DESCRIPTION
## Overview
This pull request introduces an improvement to the error messaging in the `setup.rs` script. Previously, if a user's bash profile file was missing or unreadable, the script would panic, providing a generic and potentially confusing error message. With this update, the script now provides a clear and specific error message that includes the file path and the nature of the error, thus enhancing the user experience.

## Changes
- Imported `std::path::Path` to format the file path in error messages.
- Replaced `unwrap()` with a `match` statement to handle potential errors gracefully.
- On encountering an error while reading the bash profile file, the script now prints an error message to `stderr` and returns an `Err` with the `anyhow::Error` containing the original error.

## Why ? 
The motivation for this change came from direct user feedback. The panic message was not user-friendly and could be intimidating for users, especially those who might not be familiar with Rust or the internals of `cocmd`. By providing a clear error message, we can make the tool more robust and user-friendly.

## Testing
The changes have been manually tested with scenarios where the bash profile file is:
- Present and readable (ensuring existing functionality is unaffected)
- Missing or unreadable (new error message is displayed as expected)

Further unit tests can be added to cover these scenarios if required.

## Request for Merge
As per our conversation, you've approved these changes. I believe they are ready for merge, but please review and let me know if there are any additional adjustments you'd like to see.

