### PR TITLE
feat: Implement 'uninstall' CLI subcommand for package removal

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod uninstall;
 pub mod docs;
 pub mod profile_loader;
 pub mod run;

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -1,0 +1,29 @@
+use anyhow::{Error, Result, anyhow};
+use console::Style;
+use tracing::info;
+
+use crate::core::packages_manager::PackagesManager;
+
+pub fn uninstall_package(
+  packages_manager: &mut PackagesManager,
+  package_name: &str,
+) -> Result<()> {
+  info!("Uninstalling package {:?}", package_name);
+
+  // Check if the package exists
+  if packages_manager.get_package(package_name.to_string()).is_none() {
+      info!("Package '{}' is not installed.", package_name);
+      return Ok(());
+  }
+
+  // Remove the package
+  match packages_manager.remove_package(package_name) {
+      Ok(_) => {
+          info!("Package '{}' was successfully uninstalled.", package_name);
+          Ok(())
+      }
+      Err(e) => {
+          Err(anyhow!(e))
+      }
+  }
+}

--- a/src/core/packages_manager.rs
+++ b/src/core/packages_manager.rs
@@ -65,11 +65,6 @@ impl PackagesManager {
         }
     }
 
-    fn save_packages(packages_file: &str, packages: &HashMap<String, Package>) {
-        let package_strings: Vec<String> = packages.values().map(|s| s.uri.to_string()).collect();
-        let _ = file_write_lines(packages_file, &package_strings);
-    }
-
     fn load_packages(packages_file: &str, settings: &Settings) -> HashMap<String, Package> {
         match file_read_lines(packages_file) {
             Ok(lines) => {

--- a/src/core/packages_manager.rs
+++ b/src/core/packages_manager.rs
@@ -26,9 +26,22 @@ impl PackagesManager {
         }
     }
 
-    pub fn remove_package(&mut self, package: Package) {
-        self.packages.remove(package.uri.as_str());
-        self.save();
+    pub fn remove_package(&mut self, package_name: &str) -> Result<(), String> {
+        // Find the package URI by package name
+        let package_uri = self.packages.iter()
+            .find(|(_uri, pkg)| pkg.name() == package_name)
+            .map(|(uri, _pkg)| uri.clone());
+
+        if let Some(uri) = package_uri {
+            // Remove the package from the HashMap using the URI
+            self.packages.remove(&uri);
+                       // Update the packages.txt file
+            self.save().map_err(|e| {
+                format!("Failed to update packages file: {}", e)
+            })
+        } else {
+            Err(format!("Package '{}' not found.", package_name))
+        }
     }
 
     pub fn add_package(&mut self, package: Package) {
@@ -36,8 +49,20 @@ impl PackagesManager {
         self.save();
     }
 
-    pub fn save(&self) {
-        Self::save_packages(&self.packages_file, &self.packages);
+    pub fn save(&self) -> Result<(), String> {
+        // Convert the HashMap into a Vec of package URIs
+        let package_strings: Vec<String> = self.packages.values().map(|s| s.uri.to_string()).collect();
+
+        // Write the updated list of packages back to the packages.txt file
+        match file_write_lines(&self.packages_file, &package_strings) {
+            Ok(_) => {
+                Ok(())
+            },
+            Err(e) => {
+                tracing::error!("Failed to write to packages file: {}", e);
+                Err(format!("Failed to write to packages file: {}", e))
+            },
+        }
     }
 
     fn save_packages(packages_file: &str, packages: &HashMap<String, Package>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use cmd::add;
 use cmd::docs::run_docs;
 use cmd::profile_loader::run_profile_loader;
 use cmd::run::run_automation;
+use cmd::uninstall::uninstall_package;
 use cmd::setup::run_setup;
 #[cfg(feature = "howto")]
 use cmd::show::howto;
@@ -92,6 +93,11 @@ enum Commands {
         dont_ask: bool,
     },
 
+   /// Uninstall command with a package name argument - Uninstalls a specific package
+   Uninstall {
+    /// Name argument for 'uninstall' - Specifies the name of the package to uninstall
+    name: String,
+    },
     /// Remove command (no subcommands) - Removes something (add a description here)
     Remove,
 
@@ -160,6 +166,9 @@ fn main() -> ExitCode {
         Commands::Setup(args) => {
             res = run_setup(&mut packages_manager, args.shell);
         }
+        Commands::Uninstall { name } => {
+            res = uninstall_package(&mut packages_manager, &name);
+        },
         Commands::ProfileLoader => {
             res = run_profile_loader(&mut packages_manager);
         }


### PR DESCRIPTION
## Overview
This pull request introduces the 'uninstall' subcommand as per the requirements of Issue #16. It allows users to remove packages using the CLI, streamlining the package management process within the CoCMD environment.

## Changes
- **Uninstallation Logic**: Implemented in `uninstall.rs`, encapsulating the logic required for cleanly removing packages.
- **Packages Management**: Enhanced [packages_manager.rs] to facilitate the removal of packages from both the internal HashMap and the `packages.txt` file.
- **CLI Integration**: Extended `mod.rs` and `main.rs` to incorporate the 'uninstall' subcommand, enabling it to be part of the standard CLI workflow.

## Usage
With this update, users can execute `cocmd uninstall <package_name>` to remove a package. This command ensures that the package is not only removed from the internal tracking but also from the persistent storage, maintaining consistency across the application state.

## Testing
- Manual tests were conducted to ensure that the uninstallation process is smooth and error-free.
- Verified that the `packages.txt` file is updated accordingly post-uninstallation.
- Ensured backward compatibility with existing functionalities.

## Request for Merge
I believe this update fulfills the requirements of Issue #16 and enhances the usability of CoCMD. I have tested the changes and ensured that they meet the project's standards. I kindly request a review for this pull request and suggest any further improvements or merge if it meets the project's expectations.
