### PR TITLE
66 when installaing nested cocmd package during logging is verbose

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,8 @@
                 }
             },
             "args": [
-                "install"
+                "install",
+                "docker"
             ],
             "cwd": "${workspaceFolder}"
         },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "crossterm 0.27.0",
  "dialoguer",
  "dirs",
+ "env_logger",
  "execute",
  "exitcode",
  "fs_extra",
@@ -283,6 +284,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "levenshtein",
+ "log",
  "natord",
  "openssl",
  "ratatui",
@@ -297,9 +299,6 @@ dependencies = [
  "tempdir",
  "termimad",
  "thiserror",
- "tracing",
- "tracing-subscriber",
- "tracing-tree",
  "zip",
 ]
 
@@ -559,6 +558,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -863,6 +875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +967,17 @@ name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "itertools"
@@ -1047,15 +1076,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,16 +1149,6 @@ name = "natord"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
 
 [[package]]
 name = "num_cpus"
@@ -1224,12 +1234,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1422,17 +1426,8 @@ checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.9",
- "regex-syntax 0.7.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1443,14 +1438,8 @@ checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1653,15 +1642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1802,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termimad"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,16 +1844,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
-dependencies = [
- "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -1953,19 +1932,7 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1975,48 +1942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
-]
-
-[[package]]
-name = "tracing-tree"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec6adcab41b1391b08a308cc6302b79f8095d1673f6947c2dc65ffb028b0b2d"
-dependencies = [
- "nu-ansi-term",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2086,12 +2011,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -2211,6 +2130,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "cocmd"
-version = "1.0.73"
+version = "1.0.74"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocmd"
-version = "1.0.73"
+version = "1.0.74"
 edition = "2021"
 authors = ["Moshe Roth <mzsrtgzr2@gmail.com>"]
 license = "GPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ serde = "1"
 serde_json = "1"
 serde_derive = "1"
 serde_yaml = "^0.9.0"
-tracing = "^0.1.37"
-tracing-tree = { version = "0.2.1" }
-tracing-subscriber = { version = "^0.3.11", features = ["env-filter"] }
 anyhow = "1.0.38"
 thiserror = "1.0.23"
 tempdir = "0.3.7"
@@ -42,6 +39,8 @@ ratatui = "0.23.0"
 openssl = { version = "0.10", features = ["vendored"] }
 termimad = "0.24.0"
 crossterm = "0.27.0"
+env_logger = "0.10.0"
+log = "0.4.20"
 
 [features]
 default = ["cli"]

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::{Error, Result};
 use console::Style;
 use dialoguer::Confirm;
-use tracing::info;
+use log::info;
 
 use crate::core::package::Package;
 use crate::core::packages_manager::PackagesManager;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,7 +1,7 @@
 pub mod add;
-pub mod uninstall;
 pub mod docs;
 pub mod profile_loader;
 pub mod run;
 pub mod setup;
 pub mod show;
+pub mod uninstall;

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -2,7 +2,7 @@ use std::process;
 
 use anyhow::{Error, Result};
 use dialoguer::{theme::ColorfulTheme, Select};
-use tracing::error;
+use log::error;
 
 use crate::core::packages_manager::PackagesManager;
 use crate::core::utils::cmd::parse_params;

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::{bail, Result};
 use dialoguer::{theme::ColorfulTheme, Select};
-use tracing::{error, info};
+use log::{error, info};
 
 use crate::core::packages_manager::PackagesManager;
 // add to bashrc or zshrc the following line if not exists

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -1,29 +1,27 @@
-use anyhow::{Error, Result, anyhow};
-use console::Style;
-use tracing::info;
+use anyhow::{anyhow, Result};
+
+use log::info;
 
 use crate::core::packages_manager::PackagesManager;
 
-pub fn uninstall_package(
-  packages_manager: &mut PackagesManager,
-  package_name: &str,
-) -> Result<()> {
-  info!("Uninstalling package {:?}", package_name);
+pub fn uninstall_package(packages_manager: &mut PackagesManager, package_name: &str) -> Result<()> {
+    info!("Uninstalling package {:?}", package_name);
 
-  // Check if the package exists
-  if packages_manager.get_package(package_name.to_string()).is_none() {
-      info!("Package '{}' is not installed.", package_name);
-      return Ok(());
-  }
+    // Check if the package exists
+    if packages_manager
+        .get_package(package_name.to_string())
+        .is_none()
+    {
+        info!("Package '{}' is not installed.", package_name);
+        return Ok(());
+    }
 
-  // Remove the package
-  match packages_manager.remove_package(package_name) {
-      Ok(_) => {
-          info!("Package '{}' was successfully uninstalled.", package_name);
-          Ok(())
-      }
-      Err(e) => {
-          Err(anyhow!(e))
-      }
-  }
+    // Remove the package
+    match packages_manager.remove_package(package_name) {
+        Ok(_) => {
+            info!("Package '{}' was successfully uninstalled.", package_name);
+            Ok(())
+        }
+        Err(e) => Err(anyhow!(e)),
+    }
 }

--- a/src/core/models/package_config_model.rs
+++ b/src/core/models/package_config_model.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use serde_derive::{Deserialize as De, Serialize as Se};
-use tracing::error;
+use log::error;
 
 use super::script_model::{ScriptModel, StepModel};
 use crate::core::utils::io::{from_file, from_yaml_file, normalize_path};
@@ -37,7 +37,7 @@ impl Automation {
                                     }
                                     Err(err) => {
                                         // Handle the error if needed
-                                        error!(err);
+                                        error!("{}", err);
                                         step.clone() // Return the original step on error
                                     }
                                 }
@@ -54,7 +54,7 @@ impl Automation {
                 }
                 Err(err) => {
                     // Handle the error if needed
-                    error!(err);
+                    error!("{}", err);
                 }
             }
         }

--- a/src/core/models/package_config_model.rs
+++ b/src/core/models/package_config_model.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use serde_derive::{Deserialize as De, Serialize as Se};
 use log::error;
+use serde_derive::{Deserialize as De, Serialize as Se};
 
 use super::script_model::{ScriptModel, StepModel};
 use crate::core::utils::io::{from_file, from_yaml_file, normalize_path};

--- a/src/core/models/settings.rs
+++ b/src/core/models/settings.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
 
-use tracing::error;
+use log::error;
 
 use crate::core::utils::io::from_yaml_file;
 use crate::core::utils::sys::get_os;

--- a/src/core/package.rs
+++ b/src/core/package.rs
@@ -61,10 +61,6 @@ impl Package {
         package
     }
 
-    pub fn is_exists_locally(&self) -> bool {
-        self.location.exists()
-    }
-
     pub fn is_legit_cocmd_package(&self) -> bool {
         if self.location.exists() {
             let config_file_path = Path::new(&self.location).join(consts::SOURCE_CONFIG_FILE);

--- a/src/core/package.rs
+++ b/src/core/package.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
-use tracing::{error, warn};
+use log::{error, warn};
 
 use super::utils::io::exists;
 use crate::core::consts;

--- a/src/core/packages_manager.rs
+++ b/src/core/packages_manager.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use tracing::error;
+use log::error;
 
 use crate::core::models::package_config_model::Automation;
 use crate::core::package::Package;

--- a/src/core/packages_manager.rs
+++ b/src/core/packages_manager.rs
@@ -28,17 +28,18 @@ impl PackagesManager {
 
     pub fn remove_package(&mut self, package_name: &str) -> Result<(), String> {
         // Find the package URI by package name
-        let package_uri = self.packages.iter()
+        let package_uri = self
+            .packages
+            .iter()
             .find(|(_uri, pkg)| pkg.name() == package_name)
             .map(|(uri, _pkg)| uri.clone());
 
         if let Some(uri) = package_uri {
             // Remove the package from the HashMap using the URI
             self.packages.remove(&uri);
-                       // Update the packages.txt file
-            self.save().map_err(|e| {
-                format!("Failed to update packages file: {}", e)
-            })
+            // Update the packages.txt file
+            self.save()
+                .map_err(|e| format!("Failed to update packages file: {}", e))
         } else {
             Err(format!("Package '{}' not found.", package_name))
         }
@@ -51,17 +52,16 @@ impl PackagesManager {
 
     pub fn save(&self) -> Result<(), String> {
         // Convert the HashMap into a Vec of package URIs
-        let package_strings: Vec<String> = self.packages.values().map(|s| s.uri.to_string()).collect();
+        let package_strings: Vec<String> =
+            self.packages.values().map(|s| s.uri.to_string()).collect();
 
         // Write the updated list of packages back to the packages.txt file
         match file_write_lines(&self.packages_file, &package_strings) {
-            Ok(_) => {
-                Ok(())
-            },
+            Ok(_) => Ok(()),
             Err(e) => {
-                tracing::error!("Failed to write to packages file: {}", e);
+                log::error!("Failed to write to packages file: {}", e);
                 Err(format!("Failed to write to packages file: {}", e))
-            },
+            }
         }
     }
 

--- a/src/core/utils/io.rs
+++ b/src/core/utils/io.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::error::Error;
 use std::fs;
 use std::fs::File;
@@ -34,28 +35,6 @@ pub fn normalize_path(relative_path: &str, base_path: &PathBuf) -> String {
 
 pub fn exists(path: &str) -> bool {
     Path::new(path).exists()
-}
-
-/// Creates a directory and its parents if necessary.
-///
-/// # Arguments
-///
-/// - `dir`: The directory path to create.
-pub fn mkdir(dir: &str) {
-    if fs::create_dir_all(dir).is_err() {
-        eprintln!("Failed to create directory: {}", dir);
-    }
-}
-
-/// Creates an empty file.
-///
-/// # Arguments
-///
-/// - `file`: The file path to create.
-pub fn touch(file: &str) {
-    if fs::File::create(file).is_err() {
-        eprintln!("Failed to create file: {}", file);
-    }
 }
 
 /// Reads lines from a file into a `Vec<String>`.
@@ -112,15 +91,6 @@ pub fn get_tmp_file() -> Result<std::fs::File, std::io::Error> {
     let mut tmp_file = tmp_dir.clone();
     tmp_file.push("tempfile"); // You can specify the filename here
     fs::File::create(tmp_file)
-}
-
-/// Gets the path to the system's temporary directory.
-///
-/// # Returns
-///
-/// The path to the temporary directory as a `PathBuf`.
-pub fn get_tmp() -> PathBuf {
-    std::env::temp_dir()
 }
 
 // Function to serialize a value to YAML and write it to a file

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #![allow(unused_must_use)]
 #![allow(clippy::missing_const_for_fn)]
-
 pub(crate) mod cmd;
 pub(crate) mod core;
 pub(crate) mod output;
@@ -21,7 +20,8 @@ use cmd::setup::run_setup;
 use cmd::show::howto;
 use cmd::show::{show_package, show_packages};
 use dialoguer::{Confirm, MultiSelect};
-use tracing::info;
+
+use log::info;
 use tui_app::tui_runner;
 
 pub(crate) use crate::core::models::settings::Settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,11 @@ use cmd::add;
 use cmd::docs::run_docs;
 use cmd::profile_loader::run_profile_loader;
 use cmd::run::run_automation;
-use cmd::uninstall::uninstall_package;
 use cmd::setup::run_setup;
 #[cfg(feature = "howto")]
 use cmd::show::howto;
 use cmd::show::{show_package, show_packages};
+use cmd::uninstall::uninstall_package;
 use dialoguer::{Confirm, MultiSelect};
 
 use log::info;
@@ -93,10 +93,10 @@ enum Commands {
         dont_ask: bool,
     },
 
-   /// Uninstall command with a package name argument - Uninstalls a specific package
-   Uninstall {
-    /// Name argument for 'uninstall' - Specifies the name of the package to uninstall
-    name: String,
+    /// Uninstall command with a package name argument - Uninstalls a specific package
+    Uninstall {
+        /// Name argument for 'uninstall' - Specifies the name of the package to uninstall
+        name: String,
     },
     /// Remove command (no subcommands) - Removes something (add a description here)
     Remove,
@@ -168,7 +168,7 @@ fn main() -> ExitCode {
         }
         Commands::Uninstall { name } => {
             res = uninstall_package(&mut packages_manager, &name);
-        },
+        }
         Commands::ProfileLoader => {
             res = run_profile_loader(&mut packages_manager);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use crate::output::set_tracing;
 #[derive(Parser)]
 #[command(
     author = "Moshe Roth",
-    version = "1.0.73",
+    version = "1.0.74",
     about = "
     Cocmd is a CLI utility to collaborate on anything in the CMD in the community and internal teams. 
     Use it to sync Aliases, Scripts, and Workflows."

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use tui_app::tui_runner;
 pub(crate) use crate::core::models::settings::Settings;
 use crate::core::packages_manager::PackagesManager;
 use crate::output::print_md;
-use crate::output::set_tracing;
+use crate::output::set_logging_level;
 
 /// Main CLI struct with meta-information
 #[derive(Parser)]
@@ -138,9 +138,9 @@ fn main() -> ExitCode {
     let cli = Cli::parse();
 
     if let Commands::Install { .. } = cli.command {
-        set_tracing(false);
+        set_logging_level(false);
     } else {
-        set_tracing(!cli.no_verbose);
+        set_logging_level(!cli.no_verbose);
     }
 
     let settings = Settings::new(None, None);

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,24 +1,17 @@
 use termimad::MadSkin;
-
-use tracing::metadata::LevelFilter;
-use tracing::Level;
-use tracing_subscriber::prelude::*;
+use log::{Level, LevelFilter};
 
 // Global variable to store the log level.
-static mut LOG_LEVEL: Level = Level::INFO; // Initialize with a default level.
+static mut LOG_LEVEL: Level = Level::Info; // Initialize with a default level.
 
 pub fn set_tracing(verbose: bool) {
-    let level = if verbose { Level::DEBUG } else { Level::INFO };
+    let level = if verbose { Level::Debug } else { Level::Info };
 
     // Set the desired log level using the env_logger crate or any other method.
-    std::env::set_var("RUST_LOG", level.to_string()); // Change "info" to your desired level.
+    env_logger::builder()
+        .filter_level(level.to_level_filter())
+        .init();
 
-    // Initialize the tracing subscriber with the configured level.
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_max_level(Level::TRACE) // This sets the maximum level.
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
     // Update the global log level variable.
     unsafe {
         LOG_LEVEL = level; // Set it to your desired level.
@@ -34,7 +27,7 @@ pub fn print_md(markdown: &String) {
 pub fn print_md_debug(markdown: &String) {
     // get tracking log level and if it's DEBUG than print the markdown
 
-    if unsafe { LOG_LEVEL } == LevelFilter::DEBUG {
+    if unsafe { LOG_LEVEL } == LevelFilter::Debug {
         print_md(markdown);
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -10,7 +10,7 @@ pub fn set_logging_level(verbose: bool) {
     // Set the desired log level using the env_logger crate or any other method.
     env_logger::builder()
         .filter_level(level.to_level_filter())
-        .init();
+        .try_init();
 
     // Update the global log level variable.
     unsafe {
@@ -40,11 +40,10 @@ mod tests {
 
     #[test]
     fn test_set_logging_level() {
-        // test that the global variable is set correctly
-        set_logging_level(true);
-        assert_eq!(unsafe { LOG_LEVEL }, Level::Debug);
-
         set_logging_level(false);
         assert_eq!(unsafe { LOG_LEVEL }, Level::Info);
+
+        set_logging_level(true);
+        assert_eq!(unsafe { LOG_LEVEL }, Level::Debug);
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,7 +4,7 @@ use log::{Level, LevelFilter};
 // Global variable to store the log level.
 static mut LOG_LEVEL: Level = Level::Info; // Initialize with a default level.
 
-pub fn set_tracing(verbose: bool) {
+pub fn set_logging_level(verbose: bool) {
     let level = if verbose { Level::Debug } else { Level::Info };
 
     // Set the desired log level using the env_logger crate or any other method.
@@ -29,5 +29,23 @@ pub fn print_md_debug(markdown: &String) {
 
     if unsafe { LOG_LEVEL } == LevelFilter::Debug {
         print_md(markdown);
+    }
+}
+
+
+// write a test for set_logging_level function. call it with different values and check if the global variable is set correctly and that env_logger level is correct
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_logging_level() {
+        // test that the global variable is set correctly
+        set_logging_level(true);
+        assert_eq!(unsafe { LOG_LEVEL }, Level::Debug);
+
+        set_logging_level(false);
+        assert_eq!(unsafe { LOG_LEVEL }, Level::Info);
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,5 @@
-use termimad::MadSkin;
 use log::{Level, LevelFilter};
+use termimad::MadSkin;
 
 // Global variable to store the log level.
 static mut LOG_LEVEL: Level = Level::Info; // Initialize with a default level.
@@ -31,7 +31,6 @@ pub fn print_md_debug(markdown: &String) {
         print_md(markdown);
     }
 }
-
 
 // write a test for set_logging_level function. call it with different values and check if the global variable is set correctly and that env_logger level is correct
 

--- a/src/package_provider/git.rs
+++ b/src/package_provider/git.rs
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with cocmd.  If not, see <https://www.gnu.org/licenses/>.
  */
-
+#![allow(dead_code)]
 use std::{path::Path, path::PathBuf, process::Command};
 
 use anyhow::{bail, Context, Result};

--- a/src/package_provider/hub.rs
+++ b/src/package_provider/hub.rs
@@ -24,7 +24,7 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
-use tracing::info;
+use log::info;
 
 use super::PackageProvider;
 use super::{

--- a/src/package_provider/hub.rs
+++ b/src/package_provider/hub.rs
@@ -23,8 +23,8 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
-use serde::{Deserialize, Serialize};
 use log::info;
+use serde::{Deserialize, Serialize};
 
 use super::PackageProvider;
 use super::{

--- a/src/package_provider/util/download.rs
+++ b/src/package_provider/util/download.rs
@@ -21,8 +21,8 @@ use std::io::{copy, Cursor};
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
-use sha2::{Digest, Sha256};
 use log::info;
+use sha2::{Digest, Sha256};
 pub fn download_and_extract_zip(url: &str, dest_dir: &Path) -> Result<()> {
     download_and_extract_zip_verify_sha256(url, dest_dir, None)
 }

--- a/src/package_provider/util/download.rs
+++ b/src/package_provider/util/download.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 use sha2::{Digest, Sha256};
-use tracing::info;
+use log::info;
 pub fn download_and_extract_zip(url: &str, dest_dir: &Path) -> Result<()> {
     download_and_extract_zip_verify_sha256(url, dest_dir, None)
 }

--- a/src/package_provider/util/download.rs
+++ b/src/package_provider/util/download.rs
@@ -23,9 +23,6 @@ use std::path::Path;
 use anyhow::{bail, Context, Result};
 use log::info;
 use sha2::{Digest, Sha256};
-pub fn download_and_extract_zip(url: &str, dest_dir: &Path) -> Result<()> {
-    download_and_extract_zip_verify_sha256(url, dest_dir, None)
-}
 
 pub fn download_and_extract_zip_verify_sha256(
     url: &str,
@@ -45,12 +42,6 @@ pub fn download_and_extract_zip_verify_sha256(
 pub fn read_string_from_url(url: &str) -> Result<String> {
     let buffer = download(url)?;
     let text = String::from_utf8(buffer)?;
-    Ok(text)
-}
-
-pub fn read_json_from_url(url: &str) -> Result<String> {
-    let response = reqwest::blocking::get(url)?;
-    let text = response.json()?;
     Ok(text)
 }
 

--- a/src/package_provider/util/git.rs
+++ b/src/package_provider/util/git.rs
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with cocmd.  If not, see <https://www.gnu.org/licenses/>.
  */
-
+#![allow(dead_code)]
 use std::process::Command;
 
 use lazy_static::lazy_static;

--- a/src/runner/step_runner.rs
+++ b/src/runner/step_runner.rs
@@ -5,8 +5,8 @@ use std::process::Command;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Confirm;
 
-use regex::Regex;
 use log::error;
+use regex::Regex;
 
 use super::shell::interactive_shell;
 use crate::core::models::script_model::StepParamModel;

--- a/src/runner/step_runner.rs
+++ b/src/runner/step_runner.rs
@@ -6,7 +6,7 @@ use dialoguer::theme::ColorfulTheme;
 use dialoguer::Confirm;
 
 use regex::Regex;
-use tracing::error;
+use log::error;
 
 use super::shell::interactive_shell;
 use crate::core::models::script_model::StepParamModel;


### PR DESCRIPTION
**Description**
I was unable to control tracing level for the package `reqwest` ( see [issue66](https://github.com/cocmd/cocmd/issues/66) for the full blown log)
The current logging solution in the cli was copied from other project and used 'tracing'
I read that a more common framework for logging for rust is env_logger:
https://medium.com/nerd-for-tech/logging-in-rust-e529c241f92e#:~:text=There%20are%20five%20log%20levels,and%20trace%20(lowest%20priority).

So i gave it a try and it looks better now: 
```
[2023-11-04T12:46:07Z INFO  cocmd] Ok, I will install: docker
[2023-11-04T12:46:07Z INFO  cocmd::cmd::add] Installing package "docker"
[2023-11-04T12:46:07Z INFO  cocmd::cmd::add] Package not found locally. Downloading...
[2023-11-04T12:46:07Z INFO  cocmd::package_provider::hub] fetching from hub...
2023-11-04 14:46:07.304797+0200 cocmd[88812:2449667] SecTaskLoadEntitlements failed error=22 cs_flags=20, pid=88812
2023-11-04 14:46:07.305092+0200 cocmd[88812:2449667] SecTaskCopyDebugDescription: cocmd[88812]/0#-1 LF=0
[2023-11-04T12:46:10Z INFO  cocmd::package_provider::util::download] validating sha256 signature...
[2023-11-04T12:46:10Z INFO  cocmd::cmd::add] Downloaded package to "/Users/morot/.cocmd/runtime/docker"
[2023-11-04T12:46:10Z INFO  cocmd::cmd::add] Package 'docker' was installed:
[2023-11-04T12:46:10Z INFO  cocmd::cmd::add] - ✅ 14 aliases available now
[2023-11-04T12:46:10Z INFO  cocmd::cmd::add] - ✅ 5 automations available now
[2023-11-04T12:46:10Z INFO  cocmd::cmd::add] - ✅ 2 paths available now in PATH env
[2023-11-04T12:46:10Z INFO  cocmd::cmd::add] - run `cocmd show package docker` for more details
```

**test**
test_set_logging_level
checking inputs and outputs of this function