### PR TITLE
Fix: Improved Error Handling for Non-Existent Packages in Install Process

### DIFF
--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::{Error, Result};
 use console::Style;
 use dialoguer::Confirm;
-use log::info;
+use log::{error, info};
 
 use crate::core::package::Package;
 use crate::core::packages_manager::PackagesManager;
@@ -28,6 +28,14 @@ pub fn install_package(
                 info!("Downloaded package to {:?}", downloaded_path);
             }
             Err(e) => {
+                if e.to_string().contains("unable to find package") {
+                    error!(
+                        "Error: The requested package '{}' could not be found in the cocmd hub.",
+                        package
+                    );
+                } else {
+                    error!("Error downloading package '{}': {}", package, e);
+                }
                 return Err(e);
             }
         }


### PR DESCRIPTION
This pull request addresses Issue #47: "bug: no error when trying to run missing package/automation". 

The issue was that when a user attempted to install a non-existent package using the `cocmd install` command, 
The system did not provide any error message. 

Changes made:
- Modified the `install_package` function in `add.rs` to improve error handling.
- The function now checks if the error returned from `provider.download()` is due to the package not being found. If so, it provides a clear and specific error message indicating that the requested package could not be found in the cocmd hub.
- This change ensures that users receive appropriate feedback for their actions, particularly when attempting to install packages that do not exist.

I have tested these changes locally, and they successfully address the problem described in Issue #47.

Closes #47